### PR TITLE
feat(projects): add projects section with 3 highlighted works

### DIFF
--- a/vite/src/App.jsx
+++ b/vite/src/App.jsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import './App.css'
 import AboutMe from './components/AboutMe';
 import EducationSection from './components/EducationSection';
+import Projects from './components/Projects';
 
 function App() {
   // const [count, setCount] = useState(0)
@@ -12,6 +13,7 @@ function App() {
     <div>
       <AboutMe />
       <EducationSection />
+      <Projects />
 
     </div>
   );

--- a/vite/src/components/Projects.jsx
+++ b/vite/src/components/Projects.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+const projects = [
+  {
+    title: "Rafiki Dispensary Tool",
+    description: "A web tool built to help manage dispensary workflows and patient data efficiently.",
+    link: "https://github.com/valentine54/Rafiki-Dispensary-tool"
+  },
+  {
+    title: "MediReminder App",
+    description: "An Android app to help users manage and track their medication schedules using Jetpack Compose.",
+    link: "#"
+  },
+  {
+    title: "Portfolio Website",
+    description: "This portfolio site you're viewing now—built with React, Vite, and Tailwind CSS to showcase my work and skills.",
+    link: "#"
+  }
+];
+
+export default function Projects() {
+  return (
+    <section className="py-16 px-6 bg-white">
+      <div className="max-w-6xl mx-auto text-center">
+        <h2 className="text-4xl font-bold text-black mb-12">Projects</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-10">
+          {projects.map((project, index) => (
+            <div
+              key={index}
+              className="bg-gray-50 shadow-lg rounded-lg p-6 hover:shadow-xl transition"
+            >
+              <h3 className="text-xl font-semibold mb-2 text-purple-700">{project.title}</h3>
+              <p className="text-sm text-gray-600 mb-4">{project.description}</p>
+              <a
+                href={project.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-purple-600 hover:underline"
+              >
+                View Project
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Created a reusable Projects component that lists Rafiki Dispensary Tool, MediReminder App, and Portfolio Website. Styled with Tailwind and includes links to GitHub where applicable.

Issue: #4