### PR TITLE
fix: Correct typo in Skills component

### DIFF
--- a/vite/src/components/Skills.jsx
+++ b/vite/src/components/Skills.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function Skills() {
   const skillGroups = {
-    "Programming Languages": ["Python/Djano", "JavaScript", , "Kotlin"],
+    "Programming Languages": ["Python/Django", "JavaScript", , "Kotlin"],
     "Tools & Platforms": ["Git", "GitHub", "Postman", "Figma", "Firebase"],
     "Web Development": ["HTML", "CSS", "React", "Tailwind CSS", "Django", "Vite"],
     // "Mobile Development": ["Kotlin", "Jetpack Compose", "Android Studio"],


### PR DESCRIPTION
Changes made to the Skills component to fix a typo in the programming languages section.

Closes: is-project-4th-year/build-your-portfolio-github-workflow-essentials-valentine54#3